### PR TITLE
Stop finishing certain activities

### DIFF
--- a/app/src/main/java/com/example/rum8/activities/LoginActivity.java
+++ b/app/src/main/java/com/example/rum8/activities/LoginActivity.java
@@ -14,12 +14,10 @@ import com.google.android.material.textfield.TextInputEditText;
 
 public class LoginActivity extends AppCompatActivity implements LoginControllerListener {
 
-    //member variables for text field
+    private LoginController controller;
     private TextInputEditText emailField;
     private TextInputEditText passwordField;
     private Button buttonLogin;
-
-    private LoginController controller;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,19 +28,20 @@ public class LoginActivity extends AppCompatActivity implements LoginControllerL
     }
 
     @Override
-    public void goToPasswordRecover() {
+    public void goToPasswordRecovery() {
         final Intent intent = new Intent(LoginActivity.this, PasswordRecoveryActivity.class);
         startActivity(intent);
-        finish();
     }
 
     @Override
     public void goToRegistration() {
         final Intent intent = new Intent(LoginActivity.this, RegistrationActivity.class);
         startActivity(intent);
-        finish();
     }
 
+    /**
+     * Finish this activity because it should not be the parent activity of {@link MainActivity}.
+     */
     @Override
     public void goToMainPage() {
         final Intent intent = new Intent(LoginActivity.this, MainActivity.class);
@@ -56,22 +55,16 @@ public class LoginActivity extends AppCompatActivity implements LoginControllerL
     }
 
     private void initViews() {
-
-        // override onclick goToPasswordRecovery button
         final Button button_goToPasswordRecovery = findViewById(R.id.button_password_recovery);
         button_goToPasswordRecovery.setOnClickListener(v -> controller.onGoToPasswordRecoverClicked());
 
-        // override onClick goToRegistration button
         final Button button_goToRegistration = findViewById(R.id.button_register);
         button_goToRegistration.setOnClickListener(v -> controller.onGoToRegistrationButtonClicked());
 
-        // views
         emailField = (TextInputEditText) findViewById(R.id.user_email);
         passwordField = (TextInputEditText) findViewById(R.id.user_password);
         buttonLogin = (Button) findViewById(R.id.button_login);
 
-
-        // override onClick login button
         buttonLogin.setOnClickListener(v -> {
             final String email = emailField.getText().toString();
             final String pw = passwordField.getText().toString();

--- a/app/src/main/java/com/example/rum8/activities/MainActivity.java
+++ b/app/src/main/java/com/example/rum8/activities/MainActivity.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -55,14 +54,15 @@ public class MainActivity extends AppCompatActivity implements MainControllerLis
         }
     }
 
-
     @Override
     public void goToProfileSettings() {
         final Intent intent = new Intent(MainActivity.this, ProfileSettingsActivity.class);
         startActivity(intent);
-        finish();
     }
 
+    /**
+     * Finish this activity because it should not be the parent activity of {@link LoginActivity}.
+     */
     @Override
     public void goToLogin() {
         final Intent intent = new Intent(MainActivity.this, LoginActivity.class);

--- a/app/src/main/java/com/example/rum8/activities/PasswordRecoveryActivity.java
+++ b/app/src/main/java/com/example/rum8/activities/PasswordRecoveryActivity.java
@@ -1,6 +1,5 @@
 package com.example.rum8.activities;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
 
@@ -15,40 +14,27 @@ import com.google.firebase.auth.FirebaseAuth;
 
 public class PasswordRecoveryActivity extends AppCompatActivity implements PasswordRecoveryControllerListener {
 
+    private PasswordRecoveryController controller;
     private TextInputEditText emailField;
     private TextInputEditText passwordField;
     private Button button_resetPassword;
     private Button button_goBackToLogin;
-    private PasswordRecoveryController controller;
-
-    // [START declare_auth]
     private FirebaseAuth mAuth;
-    // [END declare_auth]
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_password_recovery);
+        initViews();
+        initController();
+        mAuth = FirebaseAuth.getInstance();
+    }
 
-        // views
+    private void initViews() {
         emailField = (TextInputEditText) findViewById(R.id.user_email);
         passwordField = (TextInputEditText) findViewById(R.id.user_password);
         button_resetPassword = (Button) findViewById(R.id.button_reset_password);
         button_goBackToLogin = (Button) findViewById(R.id.button_go_back_to_login);
-
-        initViews();
-        initController();
-
-
-
-        // [START initialize_auth]
-        // Initialize Firebase Auth
-        mAuth = FirebaseAuth.getInstance();
-        // [END initialize_auth]
-
-    }
-
-    private void initViews() {
         button_goBackToLogin.setOnClickListener(v -> controller.onGoBackToLoginButtonClicked());
     }
 
@@ -56,20 +42,12 @@ public class PasswordRecoveryActivity extends AppCompatActivity implements Passw
         controller = new PasswordRecoveryController(this);
     }
 
-    // [START on_start_check_user]
-    @Override
-    public void onStart() {
-        super.onStart();
-
-    }
-
+    /**
+     * Finish this activity because {@link LoginActivity} is the parent activity of this activity.
+     */
     @Override
     public void goBackToLogin() {
-        //TODO go back to the login page
-        final Intent intent = new Intent(PasswordRecoveryActivity.this, LoginActivity.class);
-        startActivity(intent);
         finish();
     }
-    // [END on_start_check_user]
 
 }

--- a/app/src/main/java/com/example/rum8/activities/RegistrationActivity.java
+++ b/app/src/main/java/com/example/rum8/activities/RegistrationActivity.java
@@ -1,6 +1,5 @@
 package com.example.rum8.activities;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.Toast;
@@ -26,24 +25,17 @@ public class RegistrationActivity extends AppCompatActivity
         initController();
     }
 
+    /**
+     * Finish this activity because {@link LoginActivity} is the parent activity of this activity.
+     */
     @Override
-    public void onUserRegistered() {
-        final Intent intent = new Intent(RegistrationActivity.this, LoginActivity.class);
-        startActivity(intent);
+    public void goToLogin() {
         finish();
     }
 
     @Override
     public void showToast(final String message, final int toastLength) {
         Toast.makeText(RegistrationActivity.this, message, toastLength).show();
-    }
-
-    @Override
-    public void goBackToLogin() {
-        final Intent intent = new Intent(RegistrationActivity.this, LoginActivity.class);
-        startActivity(intent);
-        finish();
-
     }
 
     private void initViews() {

--- a/app/src/main/java/com/example/rum8/activities/SplashActivity.java
+++ b/app/src/main/java/com/example/rum8/activities/SplashActivity.java
@@ -22,20 +22,22 @@ public class SplashActivity extends AppCompatActivity implements SplashControlle
         setContentView(R.layout.activity_splash);
         initController();
 
-        new Handler().postDelayed(new Runnable() {
-            public void run() {
-                controller.goToNextPage();
-            }
-        }, SPLASH_DISPLAY_TIME_MS);
+        new Handler().postDelayed(() -> controller.goToNextActivity(), SPLASH_DISPLAY_TIME_MS);
     }
 
+    /**
+     * Finish this activity because it should not be the parent activity of any activity.
+     */
     @Override
-    public void goToMainPage() {
+    public void goToMain() {
         final Intent intent = new Intent(SplashActivity.this, MainActivity.class);
         startActivity(intent);
         finish();
     }
 
+    /**
+     * Finish this activity because it should not be the parent activity of any activity.
+     */
     @Override
     public void goToLogin() {
         final Intent intent = new Intent(SplashActivity.this, LoginActivity.class);

--- a/app/src/main/java/com/example/rum8/controllers/LoginController.java
+++ b/app/src/main/java/com/example/rum8/controllers/LoginController.java
@@ -72,7 +72,7 @@ public class LoginController {
     }
 
     public void onGoToPasswordRecoverClicked() {
-        controllerListener.goToPasswordRecover();
+        controllerListener.goToPasswordRecovery();
     }
 
     private void onLoginSuccessful() {

--- a/app/src/main/java/com/example/rum8/controllers/RegistrationController.java
+++ b/app/src/main/java/com/example/rum8/controllers/RegistrationController.java
@@ -43,7 +43,7 @@ public class RegistrationController {
                     ((Activity) context, task -> {
                         if (task.isSuccessful()) {
                             sendVerificationEmail(email);
-                            controllerListener.onUserRegistered();
+                            controllerListener.goToLogin();
                             // Create a new user with email when registration is complete
 
                             final Map<String, Object> userInfo = new HashMap<String, Object>() {{
@@ -100,7 +100,7 @@ public class RegistrationController {
     }
 
     public void onGoBackToLoginButtonClicked() {
-        controllerListener.goBackToLogin();
+        controllerListener.goToLogin();
     }
 
 }

--- a/app/src/main/java/com/example/rum8/controllers/SplashController.java
+++ b/app/src/main/java/com/example/rum8/controllers/SplashController.java
@@ -14,9 +14,9 @@ public class SplashController {
         auth = FirebaseAuth.getInstance();
     }
 
-    public void goToNextPage() {
+    public void goToNextActivity() {
         if (userIsLoggedIn(auth.getCurrentUser())) {
-            controllerListener.goToMainPage();
+            controllerListener.goToMain();
         } else {
             controllerListener.goToLogin();
         }

--- a/app/src/main/java/com/example/rum8/listeners/LoginControllerListener.java
+++ b/app/src/main/java/com/example/rum8/listeners/LoginControllerListener.java
@@ -2,7 +2,7 @@ package com.example.rum8.listeners;
 
 public interface LoginControllerListener {
 
-    void goToPasswordRecover();
+    void goToPasswordRecovery();
 
     void goToRegistration();
 

--- a/app/src/main/java/com/example/rum8/listeners/RegistrationControllerListener.java
+++ b/app/src/main/java/com/example/rum8/listeners/RegistrationControllerListener.java
@@ -2,10 +2,8 @@ package com.example.rum8.listeners;
 
 public interface RegistrationControllerListener {
 
-    void onUserRegistered();
+    void goToLogin();
 
     void showToast(final String message, final int toastLength);
-
-    void goBackToLogin();
 
 }

--- a/app/src/main/java/com/example/rum8/listeners/SplashControllerListener.java
+++ b/app/src/main/java/com/example/rum8/listeners/SplashControllerListener.java
@@ -2,7 +2,7 @@ package com.example.rum8.listeners;
 
 public interface SplashControllerListener {
 
-    void goToMainPage();
+    void goToMain();
 
     void goToLogin();
 


### PR DESCRIPTION
When the back button is pressed in an activity, the app will go to the parent activity. Some activities should not have parent activities. If an activity does not have a parent activity, then the app will close when the back button is pressed. You can destroy an activity by calling `finish()` within the activity.

All of our activities were always calling `finish()`, causing the app to close whenever back was pressed.